### PR TITLE
HoTT bugfix

### DIFF
--- a/openXsensor/oXs_out_hott.cpp
+++ b/openXsensor/oXs_out_hott.cpp
@@ -618,22 +618,17 @@ ISR(TIMER1_COMPA_vect)
                   if( !(GET_RX_PIN( ) == 0 )) data |= 0x80 ;  // If a logical 1 is read, let the data mirror this.
                   SwUartRXData = data ;
                } else {                                       //Done receiving =  8 bits are in SwUartRXData
-                  if ( LastRx == HOTT_BINARY_MODE_REQUEST_ID ) {     // if the previous byte identifies a polling for a reply in binary format
-                           if ( SwUartRXData == HOTT_TELEMETRY_GAM_SENSOR_ID 
+                  if ( LastRx == HOTT_BINARY_MODE_REQUEST_ID         // if previous and cuurrent byte form a valid binary format request
+                           && ( SwUartRXData == HOTT_TELEMETRY_GAM_SENSOR_ID 
 #ifdef GPS_INSTALLED                           
                               || SwUartRXData == HOTT_TELEMETRY_GPS_SENSOR_ID
 #endif                           
-                                                                               ) {// the sensor has to reply (if it has data; here we assume it has always data and the data will be in the Hott buffer)
+																)) {// the sensor has to reply (if it has data; here we assume it has always data and the data will be in the Hott buffer)
                                flagUpdateHottBuffer = SwUartRXData ;         // flag to say to send function that the buffer must be filled. It is expected that send function is called fast enough (so main loop may not be blocked) 
                                state = TxPENDING ;
                                OCR1A += ( DELAY_4000 - TICKS2WAITONEHOTT) ;                   // 4ms gap before sending; normally Hott protocols says to wait 5 msec but this is too much for timer1
                                delayTxPendingCount  = 1 ;            //  ask for 1 more delay of 1ms in order to reach the total of 5msec                 
-                           } else  {
-                                state = WAITING ;
-                                OCR1A += ( DELAY_4000 - TICKS2WAITONEHOTT) ;                // 4mS gap before listening (take care that 4096 is the max we can wait because timer 1 is 16 bits and prescaler = 1)
-                           }      // end last byte was a polling code
-
-                  } else {                                // Previous code is not equal to HOTT_BINARY_MODE_REQUEST_ID , enter to iddle mode (so we will accept to read another byte)                                 
+                  } else {                                // Previous code is not equal to HOTT_BINARY_MODE_REQUEST_ID , enter to idle mode (so we will accept to read another byte)                                 
                       DISABLE_TIMER_INTERRUPT() ;         // Stop the timer interrupts.
                       state = IDLE ;                      // Go back to idle.
                       PCIFR = ( 1<<PCIF2 ) ;              // clear pending interrupt


### PR DESCRIPTION
After receiving a request of the form 0x80 - not_our_own_id, the old
code delayed further reception for 4ms.  This causes a problem when the
receiver is turned on and the transmitter is not: The receiver will
issue requests 0x80 - 0x80 in that case. The very first request of this
form is handled as expected.  When the first byte of the second request
is received, the code still remembers the last received byte (0x80) and
thus immediately stops reception for 4ms, thereby missing the second
byte of that request.  This repeats for all further requests.  Even when
the transmitter is eventually turned on and the receiver starts issuing
requests for other sensor IDs, the code will always ignore the second
request byte and will thus not be able to transmit any telemetry.

The problem can be solved by either forcing it to forget the previous
byte in case some other than our own sensor ID is received, or by
omitting the 4ms delay until accepting further data from the receiver.
Here the latter option was chosen.