### PR TITLE
fix compilation error when FILL_TEST_1_2_3_WITH_LINEAR_ACC is defined

### DIFF
--- a/openXsensor/openXsensor.ino
+++ b/openXsensor/openXsensor.ino
@@ -981,7 +981,7 @@ void calculateAllFields () {
             test1.available = true ; 
             test2.value =  linear_acceleration_y * 981; 
             test2.available = true ; 
-            test3.value = linear_acceleration_Z * 981; 
+            test3.value = linear_acceleration_z * 981;
             test3.available = true ; 
   #endif
 


### PR DESCRIPTION
linear_acceleration_z is spelled with a lowercase 'z'.

Signed-off-by: Stefan Naewe <stefan.naewe@gmail.com>